### PR TITLE
correctly use prompts.prefix for logger dependency

### DIFF
--- a/app/templates/src/app/app.router.js
+++ b/app/templates/src/app/app.router.js
@@ -3,7 +3,7 @@
 
   angular
     .module('<%= prompts.prefix %>.Router', [
-      'my.core.utils.Logger'
+      '<%= prompts.prefix %>.core.utils.Logger'
     ])
     .run(function (appRouter, Logger) {
       var log = new Logger('<%= prompts.prefix %>.Router');

--- a/app/templates/src/app/home/views/home.js
+++ b/app/templates/src/app/home/views/home.js
@@ -3,7 +3,7 @@
 
   angular
     .module('<%= prompts.prefix %>.home.views.Home', [
-      'my.core.utils.Logger'
+      '<%= prompts.prefix %>.core.utils.Logger'
     ])
     .config(StateConfig)
     .controller('homeController', HomeController);

--- a/app/templates/src/app/layout/directives/header.directive.js
+++ b/app/templates/src/app/layout/directives/header.directive.js
@@ -3,7 +3,7 @@
 
   angular
     .module('<%= prompts.prefix %>.layout.directives.Header', [
-      'my.core.utils.Logger'
+      '<%= prompts.prefix %>.core.utils.Logger'
     ])
     .directive('<%= prompts.prefix %>Header', HeaderDirective);
 


### PR DESCRIPTION
Generator uses hardcoded "my" prefix instead of the one passed into the config making the app not work after generated