### PR TITLE
Fix Auto-Prefix tasks

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -264,6 +264,9 @@ var HirschGenerator = yeoman.generators.Base.extend({
         this.copyTpl(this.projectConfig.path.taskDir, 'css!', 'sass.js!');
     }
 
+    if(this.autoPrefixr){
+        this.copyTpl(this.projectConfig.path.taskDir, 'autoPrefixr!', 'css-auto-prefix.js!');
+    }
 
     if(this.projectConfig.prompts.useTypescript) {
       this.copyTpl(this.projectConfig.path.taskDir, 'ts!', '*.js!');

--- a/app/templates/tasks/autoPrefixr/css-auto-prefix.js
+++ b/app/templates/tasks/autoPrefixr/css-auto-prefix.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 var gulp = require('gulp');

--- a/app/templates/tasks/autoPrefixr/css-auto-prefix.js
+++ b/app/templates/tasks/autoPrefixr/css-auto-prefix.js
@@ -1,3 +1,4 @@
+
 'use strict';
 
 var gulp = require('gulp');

--- a/app/templates/tasks/inject.js
+++ b/app/templates/tasks/inject.js
@@ -10,7 +10,7 @@ var _ = require('lodash');
  * INJECT
  * Injects all bower and application scripts into the main index.html file
  */
-gulp.task('inject', ['css-auto-prefix'], function () {
+gulp.task('inject', [<% if(prompts.autoPrefixr) { %>'css-auto-prefix'<% } %>], function () {
 
   var source = [];
   source.push(path.join(projectConfig.path.srcDir, projectConfig.path.assets.css));

--- a/app/templates/tasks/inject.js
+++ b/app/templates/tasks/inject.js
@@ -10,7 +10,7 @@ var _ = require('lodash');
  * INJECT
  * Injects all bower and application scripts into the main index.html file
  */
-gulp.task('inject', [<% if(prompts.autoPrefixr) { %>'css-auto-prefix'<% } %>], function () {
+gulp.task('inject'<% if(prompts.autoPrefixr) { %>, ['css-auto-prefix']<% } %>, function () {
 
   var source = [];
   source.push(path.join(projectConfig.path.srcDir, projectConfig.path.assets.css));


### PR DESCRIPTION
When choosing not to use auto-prefixr it still generated css-auto-prefix task (which caused gulp to fail).
Additionally, inject task still depended on that task, which does not work.

This Pullrequest fixes these issues