### PR TITLE
Develop

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -46,9 +46,9 @@
     "main-bower-files":       "^2.5.0",
     "wiredep":                "^2.2.2"<% if (prompts.useTypescript) { %>,
     "tsd": "^0.6.0",
-    "typescript": "~1.4.0",
+    "typescript": "~1.6.0",
     "gulp-typescript": "^2.7.5",
-    "gulp-tslint": "^2.0.0"<% } %>
+    "gulp-tslint": "^3.0.0"<% } %>
   },
   "scripts":         {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/app/templates/src/app-ts/app.ts
+++ b/app/templates/src/app-ts/app.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %> {
+namespace <%= prompts.prefix %> {
   'use strict';
 
   angular

--- a/app/templates/src/app-ts/common/util/lazy.ts
+++ b/app/templates/src/app-ts/common/util/lazy.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %>.common.util {
+namespace <%= prompts.prefix %>.common.util {
   'use strict';
 
   export class Lazy<T> {

--- a/app/templates/src/app-ts/core/config/angular.config.ts
+++ b/app/templates/src/app-ts/core/config/angular.config.ts
@@ -3,7 +3,7 @@
 /**
  * Defines the AngularJS Modules and configures them
  */
-module <%= prompts.prefix %>.core.config {
+namespace <%= prompts.prefix %>.core.config {
   'use strict';
 
   /**

--- a/app/templates/src/app-ts/core/config/config.module.ts
+++ b/app/templates/src/app-ts/core/config/config.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.config {
+namespace <%= prompts.prefix %>.core.config {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.core.config';

--- a/app/templates/src/app-ts/core/config/thirdParty.config.ts
+++ b/app/templates/src/app-ts/core/config/thirdParty.config.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.config {
+namespace <%= prompts.prefix %>.core.config {
   'use strict';
 
   var translateConfig = ($translateProvider: ng.translate.ITranslateProvider) => {

--- a/app/templates/src/app-ts/core/constants/constants.module.ts
+++ b/app/templates/src/app-ts/core/constants/constants.module.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.constants {
+namespace <%= prompts.prefix %>.core.constants {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.core.constants';

--- a/app/templates/src/app-ts/core/constants/global.constants.ts
+++ b/app/templates/src/app-ts/core/constants/global.constants.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.constants {
+namespace <%= prompts.prefix %>.core.constants {
   'use strict';
 
   angular

--- a/app/templates/src/app-ts/core/core.module.ts
+++ b/app/templates/src/app-ts/core/core.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core {
+namespace <%= prompts.prefix %>.core {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.core';

--- a/app/templates/src/app-ts/core/router/router.config.ts
+++ b/app/templates/src/app-ts/core/router/router.config.ts
@@ -3,13 +3,13 @@
 /**
  *  Extension for 3rd party type definition file.
  */
-declare module angular.ui {
+declare namespace angular.ui {
   interface IState {
     includes?(name: string): void;
   }
 }
 
-module <%= prompts.prefix %>.core.router {
+namespace <%= prompts.prefix %>.core.router {
 
   // this variable is to prevent an issue with the default routes;
   // if the initial request to the application is for an invalid route

--- a/app/templates/src/app-ts/core/router/router.middleware.auth.ts
+++ b/app/templates/src/app-ts/core/router/router.middleware.auth.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.router {
+namespace <%= prompts.prefix %>.core.router {
   'use strict';
 
   var run = (logger: util.ILoggerFactory, $timeout: ng.ITimeoutService, routerService: IRouterService) => {

--- a/app/templates/src/app-ts/core/router/router.middleware.errorHandling.ts
+++ b/app/templates/src/app-ts/core/router/router.middleware.errorHandling.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.router {
+namespace <%= prompts.prefix %>.core.router {
   'use strict';
 
   var run = ($q: ng.IQService, routerService: IRouterService, logger: util.ILoggerFactory) => {

--- a/app/templates/src/app-ts/core/router/router.module.ts
+++ b/app/templates/src/app-ts/core/router/router.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %>.core.router {
+namespace <%= prompts.prefix %>.core.router {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.core.router';

--- a/app/templates/src/app-ts/core/router/router.service.ts
+++ b/app/templates/src/app-ts/core/router/router.service.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.router {
+namespace <%= prompts.prefix %>.core.router {
 
   export interface IRouterService {
     /**

--- a/app/templates/src/app-ts/core/util/backend.ts
+++ b/app/templates/src/app-ts/core/util/backend.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.util {
+namespace <%= prompts.prefix %>.core.util {
   'use strict';
 
   export interface IBackend {

--- a/app/templates/src/app-ts/core/util/events.ts
+++ b/app/templates/src/app-ts/core/util/events.ts
@@ -3,7 +3,7 @@
 /**
  * Event bus. Use this class to register events and trigger them from anywhere.
  */
-module <%= prompts.prefix %>.core.util {
+namespace <%= prompts.prefix %>.core.util {
   'use strict';
 
   export interface IAppEvents {

--- a/app/templates/src/app-ts/core/util/logger.ts
+++ b/app/templates/src/app-ts/core/util/logger.ts
@@ -7,7 +7,7 @@ interface Function {
   name?: string;
 }
 
-module <%= prompts.prefix %>.core.util {
+namespace <%= prompts.prefix %>.core.util {
   'use strict';
 
   export interface ILoggerFactory {

--- a/app/templates/src/app-ts/core/util/util.module.ts
+++ b/app/templates/src/app-ts/core/util/util.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.core.util {
+namespace <%= prompts.prefix %>.core.util {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.core.util';

--- a/app/templates/src/app-ts/home/home.module.ts
+++ b/app/templates/src/app-ts/home/home.module.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.home {
+namespace <%= prompts.prefix %>.home {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.home';

--- a/app/templates/src/app-ts/home/views/home.ts
+++ b/app/templates/src/app-ts/home/views/home.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %>.home.views {
+namespace <%= prompts.prefix %>.home.views {
   'use strict';
 
   var stateConfig = ($stateProvider: ng.ui.IStateProvider) => {

--- a/app/templates/src/app-ts/home/views/views.module.ts
+++ b/app/templates/src/app-ts/home/views/views.module.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.home.views {
+namespace <%= prompts.prefix %>.home.views {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.home.views';

--- a/app/templates/src/app-ts/layout/directives/directives.module.ts
+++ b/app/templates/src/app-ts/layout/directives/directives.module.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.layout.directives {
+namespace <%= prompts.prefix %>.layout.directives {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.layout.directives';

--- a/app/templates/src/app-ts/layout/directives/header.directive.ts
+++ b/app/templates/src/app-ts/layout/directives/header.directive.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.layout.directives {
+namespace <%= prompts.prefix %>.layout.directives {
   'use strict';
 
   /**

--- a/app/templates/src/app-ts/layout/layout.module.ts
+++ b/app/templates/src/app-ts/layout/layout.module.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../typings/tsd.d.ts" />
 
-module <%= prompts.prefix %>.layout {
+namespace <%= prompts.prefix %>.layout {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.layout';

--- a/app/templates/src/app-ts/layout/views/admin.ts
+++ b/app/templates/src/app-ts/layout/views/admin.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %>.layout.views {
+namespace <%= prompts.prefix %>.layout.views {
   'use strict';
 
   var stateConfig = ($stateProvider: ng.ui.IStateProvider) => {

--- a/app/templates/src/app-ts/layout/views/public.ts
+++ b/app/templates/src/app-ts/layout/views/public.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %>.layout.views {
+namespace <%= prompts.prefix %>.layout.views {
   'use strict';
 
   var stateConfig = ($stateProvider: ng.ui.IStateProvider) => {

--- a/app/templates/src/app-ts/layout/views/views.module.ts
+++ b/app/templates/src/app-ts/layout/views/views.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %>.layout.views {
+namespace <%= prompts.prefix %>.layout.views {
   'use strict';
 
   export var Namespace = '<%= prompts.prefix %>.layout.views';

--- a/app/templates/src/assets/config/_config.constant.ts
+++ b/app/templates/src/assets/config/_config.constant.ts
@@ -3,7 +3,7 @@
  */
 /// <reference path="../../../../typings/tsd.d.ts" />
 
-module my.core.constants {
+namespace my.core.constants {
   'use strict';
 
   export interface IAppConfig {

--- a/app/templates/test-ts/midway/app.spec.ts
+++ b/app/templates/test-ts/midway/app.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../typings/tsd.d.ts"/>
 
-module <%= prompts.prefix %>.test {
+namespace <%= prompts.prefix %>.test {
   'use strict';
 
   describe('Midway: Testing Modules', () => {

--- a/templates/typescript/directive.ts
+++ b/templates/typescript/directive.ts
@@ -1,27 +1,28 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
 module <%= prefix %>.<%= module %>.<%= $namespace %> {
-  'use strict';
+  'use strict';<% if (hasTemplate) { %>
+
+  const templateUrl = '<%= templateUrl %>';<% } %>
   
-  class <%= classedName %>Directive implements angular.IDirective {
+  export class <%= classedName %>Directive implements angular.IDirective {
     restrict = '<%= restrict %>';<% if (hasTemplate) { %>
-    templateUrl = '<%= templateUrl %>';<% } %><% if (hasController) { %>
+    templateUrl = templateUrl;<% } %><% if (hasController) { %>
     controller = ID.<%= classedName %>Controller;
-    controllerAs = '<%= cameledName %>';
+    controllerAs = 'vm';
     bindToController = true;<% } %><% if (hasLinkFnc) { %>
 
-    link = (scope: angular.IScope,
-            instanceElement: angular.IAugmentedJQuery,
-            instanceAttributes: angular.IAttributes<% if (hasController) { %>,
+    link = (scope: ng.IScope,
+            instanceElement: ng.IAugmentedJQuery,
+            instanceAttributes: ng.IAttributes<% if (hasController) { %>,
             controller: <%= classedName %>Controller<% } %>) => {
       // TODO: link logic
-    };<% } %>
+    };<% } %><% if (hasTemplate) { %>
+
+    static getTemplateUrl = () => templateUrl;<% } %>
   }<% if (hasController) { %>
 
-  export interface I<%= classedName %>Controller {
-  }
-
-  class <%= classedName %>Controller implements I<%= classedName %>Controller {
+  export class <%= classedName %>Controller {
     static $inject = [];
     constructor() {
       // TODO

--- a/templates/typescript/directive.ts
+++ b/templates/typescript/directive.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';<% if (hasTemplate) { %>
 
   const templateUrl = '<%= templateUrl %>';<% } %>

--- a/templates/typescript/directive.unit.spec.ts
+++ b/templates/typescript/directive.unit.spec.ts
@@ -4,18 +4,14 @@ module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
   'use strict';
 
   describe(`Unit: ${Namespace}.<%= classedName %>Directive`, () => {
-    var $compile, $rootScope;
+    let $compile: ng.ICompileService, $rootScope: ng.IRootScopeService;
 
-    beforeEach(module(Namespace));
+    beforeEach(angular.mock.module(`${Namespace}.<%= classedName %>`));
 
-    beforeEach(angular.mock.inject(
-      ['$compile', '$rootScope', ($c, $r) => {
-        $compile = $c;
-        $rootScope = $r;
-      }]
-    ));<% if (hasController) { %>
+    beforeEach(angular.mock.inject(_$compile_ => $compile = _$compile_));
+    beforeEach(angular.mock.inject(_$rootScope_ => $rootScope = _$rootScope_));<% if (hasController) { %>
 
-    var controller: I<%= classedName %>Controller;
+    let controller: <%= classedName %>Controller;
     beforeEach(inject($controller => controller = $controller(ID.<%= classedName %>Controller)));
 
     it('should contain a <%= classedName %> controller', () => should.exist(controller));<% } %>

--- a/templates/typescript/directive.unit.spec.ts
+++ b/templates/typescript/directive.unit.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %>.test {
   'use strict';
 
   describe(`Unit: ${Namespace}.<%= classedName %>Directive`, () => {

--- a/templates/typescript/directives.module.ts
+++ b/templates/typescript/directives.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
   export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';

--- a/templates/typescript/directives.module.ts
+++ b/templates/typescript/directives.module.ts
@@ -3,7 +3,7 @@
 module <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
-  export var Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
+  export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
 
   angular
     .module(Namespace, [<% for (var i = 0, l = components.length; i < l; i++) { %>
@@ -11,7 +11,7 @@ module <%= prefix %>.<%= module %>.<%= $namespace %> {
       `${Namespace}.<%= classedName %>`
     ]);
 
-  export var ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
+  export const ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
     <%= components[i] %>Controller: `${Namespace}.<%= components[i] %>Controller`, <% } %>
     <%= classedName %>Controller: `${Namespace}.<%= classedName %>Controller`
   };

--- a/templates/typescript/filter.ts
+++ b/templates/typescript/filter.ts
@@ -3,11 +3,11 @@
 module <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
-  export interface I<%= classedName %>Filter {
+  export interface I<%= classedName %> {
     (input: string): string;
   }
   
-  var <%= cameledName %> = (): I<%= classedName %>Filter => {
+  export const <%= cameledName %>Filter = (): I<%= classedName %> => {
     return input => {
       input = input || '';
 
@@ -17,9 +17,9 @@ module <%= prefix %>.<%= module %>.<%= $namespace %> {
     };
   };
 
-  <%= cameledName %>.$inject = [];
+  <%= cameledName %>Filter.$inject = [];
 
   angular
-    .module(`${Namespace}.<%= classedName %>Filter`, [])
-    .filter(ID.<%= classedName %>Filter, <%= cameledName %>);
+    .module(`${Namespace}.<%= classedName %>`, [])
+    .filter(ID.<%= classedName %>, <%= cameledName %>Filter);
 }

--- a/templates/typescript/filter.ts
+++ b/templates/typescript/filter.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts"/>
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
   export interface I<%= classedName %> {

--- a/templates/typescript/filter.unit.spec.ts
+++ b/templates/typescript/filter.unit.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %>.test {
   'use strict';
 
   describe(`Unit: ${Namespace}.<%= classedName %>`, () => {

--- a/templates/typescript/filter.unit.spec.ts
+++ b/templates/typescript/filter.unit.spec.ts
@@ -3,13 +3,13 @@
 module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
   'use strict';
 
-  describe(`Unit: ${Namespace}.<%= classedName %>Filter`, () => {
+  describe(`Unit: ${Namespace}.<%= classedName %>`, () => {
 
-    beforeEach(module(Namespace));
+    beforeEach(angular.mock.module(`${Namespace}.<%= classedName %>`));
 
-    var <%= cameledName %>: I<%= classedName %>Filter;
-    beforeEach(inject($filter => <%= cameledName %> = $filter(ID.<%= classedName %>Filter)));
+    let <%= cameledName %>Filter: I<%= classedName %>;
+    beforeEach(inject($filter => <%= cameledName %>Filter = $filter(ID.<%= classedName %>)));
 
-    it('should contain a <%= cameledName %> filter', () => should.exist(<%= cameledName %>));
+    it('should contain a <%= cameledName %> filter', () => should.exist(<%= cameledName %>Filter));
   });
 }

--- a/templates/typescript/filters.module.ts
+++ b/templates/typescript/filters.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
   export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';

--- a/templates/typescript/filters.module.ts
+++ b/templates/typescript/filters.module.ts
@@ -3,16 +3,16 @@
 module <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
-  export var Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
+  export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
 
   angular
     .module(Namespace, [<% for (var i = 0, l = components.length; i < l; i++) { %>
       `${Namespace}.<%= components[i] %>`, <% } %>
-      `${Namespace }.<%= classedName %>Filter`
+      `${Namespace }.<%= classedName %>`
     ]);
 
-  export var ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
+  export const ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
     <%= components[i] %>: '<%= components[i].charAt(0).toLowerCase() %><%= components[i].replace(/Filter$/, '').slice(1) %>', <% } %>
-    <%= classedName %>Filter: '<%= cameledName %>'
+    <%= classedName %>: '<%= cameledName %>'
   };
 }

--- a/templates/typescript/module.midway.spec.ts
+++ b/templates/typescript/module.midway.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= cameledName %>.test {
+namespace <%= prefix %>.<%= cameledName %>.test {
   'use strict';
 
   describe(`Midway: ${Namespace}.`, () => {

--- a/templates/typescript/module.ts
+++ b/templates/typescript/module.ts
@@ -3,7 +3,7 @@
 module <%= prefix %>.<%= cameledName %> {
   'use strict';
 
-  export var Namespace = '<%= prefix %>.<%= cameledName %>';
+  export const Namespace = '<%= prefix %>.<%= cameledName %>';
 
   angular
     .module(Namespace, []);

--- a/templates/typescript/module.ts
+++ b/templates/typescript/module.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= cameledName %> {
+namespace <%= prefix %>.<%= cameledName %> {
   'use strict';
 
   export const Namespace = '<%= prefix %>.<%= cameledName %>';

--- a/templates/typescript/service.ts
+++ b/templates/typescript/service.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts"/>
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
   export interface I<%= classedName %> {

--- a/templates/typescript/service.ts
+++ b/templates/typescript/service.ts
@@ -7,29 +7,30 @@ module <%= prefix %>.<%= module %>.<%= $namespace %> {
     method(param: string): string;
   }
 
-  class <%= classedName %> implements I<%= classedName %> {
+  export class <%= classedName %> implements I<%= classedName %> {
     private field;
-  
-    static $inject = [];
+    <% if(!useFactory) { %>
+    static $inject = [];<% } %>
     constructor() {
       this.field = 'value';
     }
 
     method = (param: string) => {
       return param;
-    }
+    };<% if(useFactory) { %>
+
+    static createInstance = () => {
+      // TODO: private initialization code
+
+      // TODO: pass initialization parameters to class
+      return new <%= classedName %>();
+    };<% } %>
   }<% if(useFactory) { %>
 
-  var factory = (): I<%= classedName %> => {
-    // TODO: private initialization code
-
-    // TODO: pass initialization parameters to class
-    return new <%= classedName %>();
-  };
-  factory.$inject = [];<% } %>
+  <%= classedName %>.createInstance.$inject = [];<% } %>
 
   angular
     .module(ID.<%= classedName %>, [])<% if(!useFactory) { %>
     .service(ID.<%= classedName %>, <%= classedName %>)<% } %><% if(useFactory) { %>
-    .factory(ID.<%= classedName %>, factory)<% } %>;
+    .factory(ID.<%= classedName %>, <%= classedName %>.createInstance)<% } %>;
 }

--- a/templates/typescript/service.unit.spec.ts
+++ b/templates/typescript/service.unit.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %>.test {
   'use strict';
 
   describe(`Unit: ${Namespace}.<%= classedName %>`, () => {

--- a/templates/typescript/service.unit.spec.ts
+++ b/templates/typescript/service.unit.spec.ts
@@ -5,13 +5,11 @@ module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
 
   describe(`Unit: ${Namespace}.<%= classedName %>`, () => {
 
-    beforeEach(module(Namespace));
+    beforeEach(angular.mock.module(ID.<%= classedName %>));
     
-    var service: I<%= classedName %>;
+    let service: I<%= classedName %>;
     beforeEach(angular.mock.inject([ID.<%= classedName %>, s => service = s]));
 
     it('should contain a <%= classedName %> service', () => should.exist(service));
-    
-    it('should have a method', () => should.exist(service.method));
   });
 }

--- a/templates/typescript/services.module.ts
+++ b/templates/typescript/services.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
   export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';

--- a/templates/typescript/services.module.ts
+++ b/templates/typescript/services.module.ts
@@ -3,16 +3,10 @@
 module <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
-  export var Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
+  export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
 
-  export var ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
+  export const ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
     <%= components[i] %>: `${Namespace}.<%= components[i] %>`, <% } %>
     <%= classedName %>: `${Namespace}.<%= classedName %>`
   };
-
-  angular
-    .module(Namespace, [<% for (var i = 0, l = components.length; i < l; i++) { %>
-      ID.<%= components[i] %>, <% } %>
-      ID.<%= classedName %>
-    ]);
 }

--- a/templates/typescript/view.ts
+++ b/templates/typescript/view.ts
@@ -3,16 +3,15 @@
 module <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
-  var stateConfig = ($stateProvider: ng.ui.IStateProvider) => {
+  const stateConfig = ($stateProvider: ng.ui.IStateProvider) => {
     $stateProvider
-      .state('admin.<%= module %><%= classedName %>', {
+      .state('root.<%= module %><%= classedName %>', {
         url: '/<%= url %>',
-        navigationKey: '<%= module %>',
         views: {
           'content': {
             templateUrl: '<%= templateUrl %>',
             controller: ID.<%= classedName %>Controller,
-            controllerAs: '<%= cameledName %>'
+            controllerAs: 'vm'
           }
         }
       });
@@ -20,14 +19,7 @@ module <%= prefix %>.<%= module %>.<%= $namespace %> {
 
   stateConfig.$inject = ['$stateProvider'];
 
-  export interface I<%= classedName %>Controller {
-    prop: string;
-    asyncProp: ng.IPromise<string[]>;
-    method(param: string): string;
-    action(): void;
-  }
-
-  class <%= classedName %>Controller implements I<%= classedName %>Controller {
+  export class <%= classedName %>Controller {
     prop: string;
     asyncProp: ng.IPromise<string[]>;
   
@@ -53,7 +45,9 @@ module <%= prefix %>.<%= module %>.<%= $namespace %> {
   }
 
   angular
-    .module(`${Namespace}.<%= classedName %>`, [])
+    .module(`${Namespace}.<%= classedName %>`, [
+      'ui.router.state'  
+    ])
     .config(stateConfig)
     .controller(ID.<%= classedName %>Controller, <%= classedName %>Controller);
 }

--- a/templates/typescript/view.ts
+++ b/templates/typescript/view.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts"/>
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
   const stateConfig = ($stateProvider: ng.ui.IStateProvider) => {

--- a/templates/typescript/view.unit.spec.ts
+++ b/templates/typescript/view.unit.spec.ts
@@ -5,9 +5,9 @@ module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
 
   describe(`Unit: ${Namespace}.<%= classedName %>Controller`, () => {
 
-    beforeEach(module(Namespace));
+    beforeEach(angular.mock.module(`${Namespace}.<%= classedName %>`));
 
-    var controller: I<%= classedName %>Controller;
+    let controller: <%= classedName %>Controller;
     beforeEach(inject($controller => controller = $controller(ID.<%= classedName %>Controller)));
 
     it('should contain a <%= classedName %> controller', () => should.exist(controller));

--- a/templates/typescript/view.unit.spec.ts
+++ b/templates/typescript/view.unit.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %>.test {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %>.test {
   'use strict';
 
   describe(`Unit: ${Namespace}.<%= classedName %>Controller`, () => {

--- a/templates/typescript/views.module.ts
+++ b/templates/typescript/views.module.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="../../../../<%= typingNesting %>typings/tsd.d.ts" />
 
-module <%= prefix %>.<%= module %>.<%= $namespace %> {
+namespace <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
   export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';

--- a/templates/typescript/views.module.ts
+++ b/templates/typescript/views.module.ts
@@ -3,7 +3,7 @@
 module <%= prefix %>.<%= module %>.<%= $namespace %> {
   'use strict';
 
-  export var Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
+  export const Namespace = '<%= prefix %>.<%= module %>.<%= $namespace %>';
 
   angular
     .module(Namespace, [
@@ -14,7 +14,7 @@ module <%= prefix %>.<%= module %>.<%= $namespace %> {
       `${Namespace}.<%= classedName %>`
     ]);
 
-  export var ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
+  export const ID = {<% for (var i = 0, l = components.length; i < l; i++) { %>
     <%= components[i] %>Controller: `${Namespace}.<%= components[i] %>Controller`, <% } %>
     <%= classedName %>Controller: `${Namespace}.<%= classedName %>Controller`
   };


### PR DESCRIPTION
Cleaned up and adapted the TypeScript part of the generator to follow new coding best practices.

Changes include:
- updated TypeScript 1.4 -> 1.6 (allows use of `let` and `const` instead of `var` amongst other things)
- updated gulp-tslint 2.X.X -> 3.X.X
- replaced obsolete `module` keyword with `namespace`
- all tests only instantiate the module of the component under test instead of the whole namespace of the component
- directives don't use interface for controller
- directives make template URL accessible to the outside
- removed name redundancies for filters
- class and factory for services are exported
- views don't use interface for controller
- views and directives use `controllerAs: 'vm'`